### PR TITLE
Package name: `cihai[cli]` -> `cihai-cli`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,8 +1,32 @@
 # Changelog
 
-## cihai 0.15.x (unreleased)
+## cihai 0.16.x (unreleased)
 
 - _Insert changes/features/fixes for next release here_
+
+## cihai 0.15.0 (2022-08-20)
+
+### Breaking changes
+
+The CLI version of `cihai` installed through `cihai-cli` again
+
+Before (cihai 0.9 to 0.14, cihai-cli 0.5 to 0.10):
+
+```console
+$ pip install cihai[cli]
+```
+
+After (cihai 0.15+, cihai-cli 0.11+):
+
+```console
+$ pip install cihai-cli
+```
+
+This made deploying cihai + cihai-cli and pinning packages extremely laborious.
+
+We can reinvestigate this model in the future.
+
+via: **[cihai#326](https://github.com/cihai/cihai/pull/326)**, [cihai-cli#279](https://github.com/cihai/cihai-cli/pull/279)
 
 ## cihai 0.14.1 (2022-08-20)
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ See [API](https://cihai.git-pull.com/api.html) documentation and
 ### CLI ([cihai-cli](https://cihai-cli.git-pull.com))
 
 ```console
-$ pip install --user 'cihai[cli]'
+$ pip install --user 'cihai-cli'
 ```
 
 Character lookup:
@@ -58,6 +58,7 @@ ucn: U+597D
 ```
 
 Reverse lookup:
+
 ```console
 $ cihai reverse library
 char: 圕

--- a/poetry.lock
+++ b/poetry.lock
@@ -105,23 +105,10 @@ python-versions = ">=3.6.0"
 unicode_backport = ["unicodedata2"]
 
 [[package]]
-name = "cihai-cli"
-version = "0.10.0"
-description = "Command line frontend for the cihai CJK language library"
-category = "main"
-optional = true
-python-versions = ">=3.7,<4.0"
-
-[package.dependencies]
-cihai = ">=0.12.0,<0.15.0"
-click = ">=7"
-PyYAML = ">=3.12,<6"
-
-[[package]]
 name = "click"
 version = "8.1.3"
 description = "Composable command line interface toolkit"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 
@@ -145,7 +132,7 @@ requests = ">=2.7.9"
 name = "colorama"
 version = "0.4.5"
 description = "Cross-platform colored terminal text."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -219,7 +206,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 name = "importlib-metadata"
 version = "4.12.0"
 description = "Read metadata from Python packages"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 
@@ -918,7 +905,7 @@ python-versions = "*"
 name = "typing-extensions"
 version = "4.3.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 
@@ -979,7 +966,7 @@ python-versions = "*"
 name = "zipp"
 version = "3.8.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 
@@ -988,7 +975,6 @@ testing = ["pytest-mypy (>=0.9.1)", "pytest-black (>=0.3.7)", "func-timeout", "j
 docs = ["jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "jaraco.packaging (>=9)", "sphinx"]
 
 [extras]
-cli = ["cihai-cli"]
 coverage = []
 docs = []
 format = []
@@ -998,7 +984,7 @@ test = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "463aa61123cfff4dd34161f9c315639755c4a99269cf3116649b25be4f4f136e"
+content-hash = "d6e4ea3ce87e18c66ffbf68433536fb8e64e064353fe1b338ec640dd87689ecc"
 
 [metadata.files]
 alabaster = [
@@ -1056,10 +1042,6 @@ certifi = [
 charset-normalizer = [
     {file = "charset-normalizer-2.1.1.tar.gz", hash = "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845"},
     {file = "charset_normalizer-2.1.1-py3-none-any.whl", hash = "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"},
-]
-cihai-cli = [
-    {file = "cihai-cli-0.10.0.tar.gz", hash = "sha256:b91144b28e33ce119d656302e46851cc3d8f66c71360483253e00720cd9902c4"},
-    {file = "cihai_cli-0.10.0-py3-none-any.whl", hash = "sha256:c06f570609cc727ef2370804e2378b80baa65a83fd0846928323eb085f0b16bd"},
 ]
 click = [
     {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ kaptan = "*"
 sqlalchemy = "<1.4"
 appdirs = "*"
 unihan-etl = "~=0.15.0"
-cihai-cli = { version = "~=0.10.0", optional = true }
 
 [tool.poetry.dev-dependencies]
 ### Docs ###
@@ -96,7 +95,6 @@ types-appdirs = "^1.4.3"
 types-colorama = "^0.4.15"
 
 [tool.poetry.extras]
-"cli" = ["cihai-cli"]
 docs = [
   "docutils",
   "sphinx",


### PR DESCRIPTION
**https://github.com/cihai/cihai/pull/326**, https://github.com/cihai/cihai-cli/pull/279

The CLI version of `cihai` installed through `cihai-cli` again

Old (cihai 0.9 to 0.14, cihai-cli 0.5 to 0.10):

```console
$ pip install cihai[cli]
```

After (cihai 0.15+, cihai-cli 0.11+):

```console
$ pip install cihai-cli
```

This made deploying cihai + cihai-cli and pinning packages extremely laborious.

We can reinvestigate this model in the future.