### PR TITLE
docs: Move to sphinx-autoissues

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,10 @@
 
 - _Insert changes/features/fixes for next release here_
 
+### Documentation
+
+- Render changelog with sphinx-autoissues, #327
+
 ## cihai 0.16.0 (2022-08-21)
 
 Purely on the inside. We're adding comprehensive type annotations to all cihai

--- a/CHANGES
+++ b/CHANGES
@@ -93,7 +93,7 @@ Infrastructure updates for static type checking and doctest examples.
 
 ## cihai 0.12.0 (2021-06-16)
 
-- {issue}`291`: Convert to markdown
+- #291: Convert to markdown
 
 ## cihai 0.11.1 (2021-06-15)
 
@@ -104,7 +104,7 @@ Infrastructure updates for static type checking and doctest examples.
 - Update {}`black` to 21.6b0
 - Update trove classifiers to 3.9
 - Update unihan-etl to 0.12.0 (removes python 2.7, 3.5 support)
-- {issue}`288` Remove python 2.7, 3.5 support. Remove `__future__` and unused modesets
+- #288 Remove python 2.7, 3.5 support. Remove `__future__` and unused modesets
 
 ## cihai 0.10.0 (2020-08-09)
 
@@ -112,12 +112,12 @@ Infrastructure updates for static type checking and doctest examples.
 
   resolver: <https://pip.pypa.io/en/stable/user_guide/#resolver-changes-2020>
 
-- {issue}`285` Move packaging / publishing to poetry
-- {issue}`284` Self host docs
-- {issue}`284` Add metadata / icons / etc. for doc site
-- {issue}`284` Move travis -> github actions
-- {issue}`284` Overhaul Makefiles
-- {issue}`283` Move from Pipfile to poetry
+- #285 Move packaging / publishing to poetry
+- #284 Self host docs
+- #284 Add metadata / icons / etc. for doc site
+- #284 Move travis -> github actions
+- #284 Overhaul Makefiles
+- #283 Move from Pipfile to poetry
 - Improvements to plugin/extension system
 
 ## cihai 0.9.0p1 (2019-08-18)
@@ -248,9 +248,9 @@ Infrastructure updates for static type checking and doctest examples.
 - Automatically reflect database schemas and make available in main cihai object
 - Use click library for CLI
 - Initial support for character lookups via `$ cihai info <char>`.
-- {issue}`3` Bootstrap UNIHAN into cihai by default via unihan-tabular project
-- {issue}`4` Drop python 3.3 and 3.4 support
-- {issue}`4` Initial [XDG][xdg] base directory support
+- #3 Bootstrap UNIHAN into cihai by default via unihan-tabular project
+- #4 Drop python 3.3 and 3.4 support
+- #4 Initial [XDG][xdg] base directory support
 - Move tests to pytest functions and fixtures
 - Remove unused test_unihan file
 - PEP8, sort imports

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ extensions = [
     "sphinx.ext.linkcode",
     "sphinx_inline_tabs",
     "sphinx_copybutton",
-    "sphinx_issues",
+    "sphinx_autoissues",
     "sphinxext.opengraph",
     "sphinxext.rediraffe",
     "myst_parser",
@@ -100,8 +100,9 @@ copybutton_prompt_text = (
 copybutton_prompt_is_regexp = True
 copybutton_remove_prompts = True
 
-# sphinx-issues
-issues_github_path = "cihai/cihai"
+# sphinx-autoissues
+issuetracker = "github"
+issuetracker_project = "cihai/cihai"
 
 # sphinxext-rediraffe
 rediraffe_redirects = "redirects.txt"

--- a/poetry.lock
+++ b/poetry.lock
@@ -729,22 +729,6 @@ doc = ["furo", "myst-parser"]
 test = ["pytest", "pytest-cov", "pytest-xdist"]
 
 [[package]]
-name = "sphinx-issues"
-version = "3.0.1"
-description = "A Sphinx extension for linking to your project's issue tracker"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-sphinx = "*"
-
-[package.extras]
-dev = ["flake8 (==3.9.2)", "flake8-bugbear (==20.11.1)", "pre-commit (>=2.7,<3.0)", "pytest (>=6.2.0)", "tox"]
-lint = ["flake8 (==3.9.2)", "flake8-bugbear (==20.11.1)", "pre-commit (>=2.7,<3.0)"]
-tests = ["pytest (>=6.2.0)"]
-
-[[package]]
 name = "sphinxcontrib-applehelp"
 version = "1.0.2"
 description = "sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books"
@@ -992,7 +976,7 @@ test = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "bcdefaaa6ab1110fe5c8d9265aa4e569b60eec9eca2a3e3c57369f15a6e1759f"
+content-hash = "2e5f214e6f7f7ced5ab4903fae4ac32a13b09564b5034a325da18f7a32926b37"
 
 [metadata.files]
 alabaster = [
@@ -1383,10 +1367,6 @@ sphinx-copybutton = [
 sphinx-inline-tabs = [
     {file = "sphinx_inline_tabs-2021.4.11b8-py3-none-any.whl", hash = "sha256:efd6e7ad576a6bc1c616cbaa9b0e6f6fe2b28a776947069ed8d6037667799808"},
     {file = "sphinx_inline_tabs-2021.4.11b8.tar.gz", hash = "sha256:3c4d7759cbbb7752b7e7acd96ed0ea2c58fcc4ae38891a718544b931a5a4818f"},
-]
-sphinx-issues = [
-    {file = "sphinx-issues-3.0.1.tar.gz", hash = "sha256:b7c1dc1f4808563c454d11c1112796f8c176cdecfee95f0fd2302ef98e21e3d6"},
-    {file = "sphinx_issues-3.0.1-py3-none-any.whl", hash = "sha256:8b25dc0301159375468f563b3699af7a63720fd84caf81c1442036fcd418b20c"},
 ]
 sphinxcontrib-applehelp = [
     {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -677,6 +677,14 @@ testing = ["covdefaults (>=2.2)", "coverage (>=6.4.2)", "diff-cover (>=6.5.1)", 
 type_comments = ["typed-ast (>=1.5.4)"]
 
 [[package]]
+name = "sphinx-autoissues"
+version = "0.0.1"
+description = "Sphinx integration with different issuetrackers"
+category = "dev"
+optional = false
+python-versions = ">=3.7,<4.0"
+
+[[package]]
 name = "sphinx-basic-ng"
 version = "0.0.1a12"
 description = "A modern skeleton for Sphinx themes."
@@ -984,7 +992,7 @@ test = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "ce474be754fb35715920cdf16a39d155d468dee98a764f9da5af81a118a61ee8"
+content-hash = "bcdefaaa6ab1110fe5c8d9265aa4e569b60eec9eca2a3e3c57369f15a6e1759f"
 
 [metadata.files]
 alabaster = [
@@ -1359,6 +1367,10 @@ sphinx-autobuild = [
 sphinx-autodoc-typehints = [
     {file = "sphinx_autodoc_typehints-1.19.2-py3-none-any.whl", hash = "sha256:3d761de928d5a86901331133d6d4a2552afa2e798ebcfc0886791792aeb4dd9a"},
     {file = "sphinx_autodoc_typehints-1.19.2.tar.gz", hash = "sha256:872fb2d7b3d794826c28e36edf6739e93549491447dcabeb07c58855e9f914de"},
+]
+sphinx-autoissues = [
+    {file = "sphinx-autoissues-0.0.1.tar.gz", hash = "sha256:a308fd914d700ff2aa2b4584c29975a030ede7171898130ec816eca7ec2c8ce8"},
+    {file = "sphinx_autoissues-0.0.1-py3-none-any.whl", hash = "sha256:07503b774c3a64b97d2614fa409410316fbfeb87ba4553dbe3a7d2131b7453a0"},
 ]
 sphinx-basic-ng = [
     {file = "sphinx_basic_ng-0.0.1a12-py3-none-any.whl", hash = "sha256:e8b6efd2c5ece014156de76065eda01ddfca0fee465aa020b1e3c12f84570bbe"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ sphinx-inline-tabs = { version = "*", python = "^3.7" }
 sphinxext-opengraph = "*"
 sphinx-copybutton = "*"
 sphinxext-rediraffe = "*"
+sphinx-autoissues = "*"
 myst_parser = "*"
 docutils = "~0.18.0"
 
@@ -106,6 +107,7 @@ docs = [
   "sphinxext-opengraph",
   "sphinx-inline-tabs",
   "sphinxext-rediraffe",
+  "sphinx-autoissues",
   "myst_parser",
   "furo",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ sphinx-argparse = "*"
 furo = "*"
 sphinx-autobuild = "*"
 sphinx-autodoc-typehints = "*"
-sphinx-issues = "*"
 sphinx-inline-tabs = { version = "*", python = "^3.7" }
 sphinxext-opengraph = "*"
 sphinx-copybutton = "*"
@@ -99,7 +98,6 @@ types-colorama = "^0.4.15"
 docs = [
   "docutils",
   "sphinx",
-  "sphinx-issues",
   "sphinx-argparse",
   "sphinx-autodoc-typehints",
   "sphinx-autobuild",


### PR DESCRIPTION
https://github.com/tony/sphinx-autoissues ([Homepage](https://sphinx-autoissues.git-pull.com/))

This is a fork of [sphinxcontrib-issuetracker](https://github.com/lunaryorn/sphinxcontrib-issuetracker) but heavily modified. In the end the similarities between the packages may be less: But the major point is we want plain text issues to be linked

unihan-db and unihan-etl already did this directly to master / trunk