### PR TITLE
ci(tests) Verify runtime deps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,18 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
 
+      - name: Test runtime dependencies
+        run: |
+          uv run --no-dev -p python${{ matrix.python-version }} -- python -c '
+          from cihai import _internal, data, config, constants, conversion, core, db, exc, extend, log, types, utils, __about__, __version__
+          from cihai._internal import config_reader, types
+          from cihai.data import decomp, unihan
+          from cihai.data.unihan import bootstrap, constants, dataset
+          from unihan_etl import __version__ as __unihan_etl_version__
+          print("cihai version:", __version__)
+          print("unihan_etl version:", __unihan_etl_version__)
+          '
+
       - name: Install dependencies
         run: uv sync --all-extras --dev
 


### PR DESCRIPTION
## Changes
- Add runtime dependency check in CI using `uv run --no-dev`
- Run check before installing dev dependencies
- Print package version and basic functionality test results
- Document improvement in `CHANGES`

## Summary by Sourcery

Adds a CI check to verify runtime dependencies are correctly installed and functional before installing dev dependencies.

CI:
- Adds a CI check to verify runtime dependencies using `uv run --no-dev` before installing dev dependencies.

Tests:
- Adds a basic functionality test that prints package versions to verify runtime dependencies.

Chores:
- Documents the improvement in `CHANGES`.