### PR TITLE
docs(fix) Resolve pre-existing Sphinx warnings and broken xrefs

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -39,6 +39,12 @@ _Notes on the upcoming release will go here._
 
 - Bump unihan-etl v0.39.1 -> v0.41.0 (#393)
 
+### Documentation
+
+- Resolve pre-existing Sphinx warnings and broken xrefs in core
+  docstrings, glossary, internals toctree, and `cihai.conversion`
+  cross-reference (#397)
+
 ## cihai 0.36.1 (2026-01-24)
 
 ### Breaking changes

--- a/docs/api/conversion.md
+++ b/docs/api/conversion.md
@@ -1,4 +1,4 @@
-(cihai-conversion)=
+(cihai.conversion)=
 
 # Conversion - `cihai.conversion`
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -6,8 +6,9 @@
 .. glossary::
 
     CJK
-        1. In computer software, `internationalization`_ of *Chinese, Japanese,
-           and Korean* language.
+        1. In computer software, `internationalization
+           <https://en.wikipedia.org/wiki/Internationalization_and_localization>`_
+           of *Chinese, Japanese, and Korean* language.
         2. In cihai, specifically, character information from Chinese,
            Japanese and Korean languages. Such as definitions, dictionary
            index references, phonetics, character decompositions and

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 # cihai
 
-Python library for [CJK](glossary.md#term-cjk) (Chinese, Japanese, Korean)
+Python library for {term}`CJK` (Chinese, Japanese, Korean)
 character data. Look up readings, definitions, and variants from the
 [UNIHAN](datasets/unihan.md) database and beyond.
 

--- a/docs/internals/index.md
+++ b/docs/internals/index.md
@@ -30,6 +30,5 @@ Internal type aliases and protocols.
 ```{toctree}
 :hidden:
 
-api/config_reader
-api/types
+api/index
 ```

--- a/src/cihai/core.py
+++ b/src/cihai/core.py
@@ -67,13 +67,12 @@ class Cihai:
     Examples
     --------
     To use cihai programmatically, invoke and install the `UNIHAN
-    <https://www.unicode.org/reports/tr38/>`_ dataset:
+    <https://www.unicode.org/reports/tr38/>`_ dataset — see
+    :ref:`examples` for a runnable walkthrough based on
+    ``examples/basic_usage.py``.
 
-    .. literalinclude:: ../examples/basic_usage.py
-        :language: python
-
-    Above: :attr:`~cihai.data.unihan.bootstrap.is_bootstrapped` can check if the system
-    has the database installed.
+    :attr:`~cihai.data.unihan.bootstrap.is_bootstrapped` can check if the
+    system has the database installed.
     """
 
     #: :py:class:`dict` of default config, can be monkey-patched during tests

--- a/src/cihai/core.py
+++ b/src/cihai/core.py
@@ -48,10 +48,6 @@ class Cihai:
 
     By default, this automatically adds the UNIHAN dataset.
 
-    Attributes
-    ----------
-    config : dict
-
     Notes
     -----
     Inspired by the early `pypa/warehouse <https://github.com/pypa/warehouse>`_

--- a/src/cihai/core.py
+++ b/src/cihai/core.py
@@ -54,7 +54,8 @@ class Cihai:
 
     Notes
     -----
-    Inspired by the early pypa/warehouse application object [1]_.
+    Inspired by the early `pypa/warehouse <https://github.com/pypa/warehouse>`_
+    application object.
 
     **Configuration templates**
 
@@ -65,20 +66,14 @@ class Cihai:
 
     Examples
     --------
-    To use cihai programmatically, invoke and install the UNIHAN [2]_ dataset:
+    To use cihai programmatically, invoke and install the `UNIHAN
+    <https://www.unicode.org/reports/tr38/>`_ dataset:
 
     .. literalinclude:: ../examples/basic_usage.py
         :language: python
 
     Above: :attr:`~cihai.data.unihan.bootstrap.is_bootstrapped` can check if the system
     has the database installed.
-
-    References
-    ----------
-    .. [1] PyPA Warehouse on GitHub. https://github.com/pypa/warehouse.
-       Accessed sometime in 2013.
-    .. [2] UNICODE HAN DATABASE (UNIHAN) documentation.
-       https://www.unicode.org/reports/tr38/. Accessed March 31st, 2018.
     """
 
     #: :py:class:`dict` of default config, can be monkey-patched during tests

--- a/src/cihai/extend.py
+++ b/src/cihai/extend.py
@@ -3,7 +3,7 @@ Cihai Plugin System.
 
 Status: Experimental, API can change
 
-As a pilot, the UNIHAN library, and an plugin for it, in #131 [1]_
+As a pilot, the UNIHAN library, and an plugin for it, in #131.
 
 You can bring any data layout / backend you like to cihai.
 


### PR DESCRIPTION
## Summary

- **Fix** unresolved `[1]_` / `[2]_` footnote references in the `cihai.core.Cihai` class docstring and a dangling `[1]_` in `cihai.extend`'s module docstring. Napoleon processes NumPy sections as independent fragments, so docutils never resolves numeric footnote targets across section boundaries; every build emitted `Unknown target name` errors. Switches to inline `` `name <url>`_ `` hyperlinks that resolve at the token level.
- **Remove** the `.. literalinclude:: ../examples/basic_usage.py` directive embedded in the `Cihai` class docstring. Autodoc resolved the path relative to the consuming page (`docs/api/core.md`), producing a non-existent `docs/examples/basic_usage.py` and a `Include file not found` warning. The example is already present at `docs/topics/examples.md`; the docstring now cross-references `:ref:`` examples`` instead.
- **Drop** the redundant `Attributes` section from the `Cihai` class docstring. The class-body annotation `config: ConfigDict` already registers the attribute via autodoc's `:members:`, so the NumPy `Attributes` list produced a duplicate object description warning on every build.
- **Fix** the orphan `docs/internals/api/index.md` by replacing the parent toctree's direct `api/config_reader` + `api/types` entries with a single `api/index` pointer. The Internal API landing page now appears in the navigation tree instead of being silently unreachable.
- **Replace** the broken `[CJK](glossary.md#term-cjk)` markdown link in `docs/index.md` with the idiomatic `` {term}`CJK` `` myst role. Sphinx generates glossary anchors as `term-CJK` (case-preserving); the lowercase fragment never resolved. The `{term}` role goes through sphinx's std domain and is immune to anchor-casing drift.
- **Rewrite** the dangling `` `internationalization`_ `` reference in `docs/glossary.md` as an inline `` `name <url>`_ `` hyperlink targeting the Wikipedia i18n article; no matching target definition existed previously, so docutils emitted an `Unknown target name` error.
- **Rename** the myst target in `docs/api/conversion.md` from `(cihai-conversion)=` to `(cihai.conversion)=` to match the `` {ref}`cihai.conversion <cihai.conversion>` `` call site in `docs/topics/features.md`. Sphinx's ref resolver is exact-match, so the hyphen/dot mismatch produced an `undefined label` warning.

## Why now

Each of these bugs reproduces on `master` today with the unchanged `gp-sphinx==0.0.1a1` pin — none are caused by any dependency upgrade. They were surfaced while diagnosing a separate set of Sphinx messages on the `api-styling` branch (which bumps gp-sphinx 0.0.1a5→0.0.1a6, PR #396). Shipping them here keeps PR #396 narrowly scoped to the dependency bump, lets the docs cleanups land regardless of when the gp-sphinx prerelease cuts, and gives every commit a message that describes the real pre-existing bug rather than framing it as a side-effect of the upgrade.

## Changes by area

### `src/cihai/core.py`

**`class Cihai` docstring**: drop the `Attributes` section, drop the `References` section with the numeric footnote targets, drop the `.. literalinclude::` directive, convert the two `[1]_`/`[2]_` footnote references to inline `` `pypa/warehouse <…>`_ `` and `` `UNIHAN <…>`_ `` hyperlinks, and add a `:ref:`` examples`` cross-reference so readers still reach the runnable example.

### `src/cihai/extend.py`

**Module docstring**: remove the dangling `[1]_` suffix from the sentence describing UNIHAN as the pilot plugin — no target definition ever existed, the sentence already names issue `#131`.

### `docs/api/conversion.md`

**Myst target**: rename `(cihai-conversion)=` to `(cihai.conversion)=` so the `{ref}` call site in `docs/topics/features.md` resolves.

### `docs/glossary.md`

**CJK entry**: inline the Wikipedia internationalization link instead of relying on a `` `internationalization`_ `` named-reference target that never existed.

### `docs/index.md`

**CJK cross-reference**: replace the raw markdown link with the `{term}` myst role.

### `docs/internals/index.md`

**Hidden toctree**: single `api/index` entry in place of the direct `api/config_reader` + `api/types` entries so the Internal API landing page is no longer orphaned.

## Design decisions

**Inline hyperlinks instead of named reference targets** — `` `name <url>`_ `` embeds the target URI at the token level and is resolved during inline parsing, so it is immune to the section-boundary fragmentation that napoleon imposes when converting NumPy docstrings. Named `.. _name: url` targets would also have worked, but they are fragile in docstrings because they can only live in the same RST fragment as the reference, which is hard to guarantee once napoleon splits the docstring into per-section chunks.

**`{term}` role instead of a manual glossary anchor** — myst's `{term}` role dispatches through sphinx's std domain, which records the glossary term by both slug and display name. This survives future changes to sphinx's anchor-generation rules (case-preserving vs case-normalizing) without the callsite needing to know which id format is current. Hard-coding a fragment like `#term-CJK` would break again the next time sphinx changes that behaviour.

**Dotted module labels over hyphenated ones** — renaming the target on `docs/api/conversion.md` to match the call site keeps the label identity aligned with the Python module name (`cihai.conversion`) as readers already write it in `{ref}` and `:mod:` invocations. The alternative — changing every call site to the hyphenated form — would have been a wider blast radius for the same net effect.

**Single `api/index` toctree entry instead of listing the leaves twice** — the Internal API landing page already contains a toctree enumerating `config_reader` and `types`. Routing the parent through `api/index` makes that landing page the single source of truth for the internals layout. The alternative was adding `api/index` alongside the two leaves, but that would duplicate the Internal API in the navigation tree.

## Scope comparison

Fresh `sphinx-build -a -E` on each branch (same `master` toolchain pin):

| Branch   | WARNING | ERROR |
|----------|--------:|------:|
| `master` |      29 |    11 |
| this PR  |      24 |     7 |
| delta    |      −5 |    −4 |

Errors eliminated:

| Message | Location |
|---------|----------|
| `Unknown target name: "1"` | `cihai.core.Cihai` docstring (line 13 of the rendered fragment) |
| `Unknown target name: "2"` | `cihai.core.Cihai` docstring (line 24 of the rendered fragment) |
| `Unknown target name: "1"` | `cihai.extend` module docstring |
| `Unknown target name: "internationalization"` | `docs/glossary.md` CJK entry |

Warnings eliminated:

| Message | Location |
|---------|----------|
| `Include file '.../docs/examples/basic_usage.py' not found` | `cihai.core.Cihai` docstring literalinclude |
| `duplicate object description of cihai.core.Cihai.config` | NumPy `Attributes` section + class-body annotation |
| `document isn't included in any toctree` | `docs/internals/api/index.md` |
| `local id not found in doc 'glossary': 'term-cjk'` | `docs/index.md` CJK markdown link |
| `undefined label: 'cihai.conversion'` | `docs/topics/features.md` ref to `docs/api/conversion.md` |

## Verification

Reproduce each eliminated message on `master`:

```console
$ git checkout master
```

```console
$ uv run sphinx-build -a -E -b dirhtml docs docs/_build/html 2>&1 | rg 'Unknown target name|duplicate object description|Include file|isn.t included in any toctree|term-cjk|cihai\.conversion'
```

Confirm absence on this branch:

```console
$ git checkout docs-fix-sphinx-warnings
```

```console
$ uv run sphinx-build -a -E -b dirhtml docs docs/_build/html 2>&1 | rg 'Unknown target name|duplicate object description|Include file|isn.t included in any toctree|term-cjk|cihai\.conversion'
```

The second command should return zero matches.

## Test plan

- [x] `uv run ruff check . --fix --show-fixes` — no lint violations
- [x] `uv run ruff format .` — no formatting drift
- [x] `uv run mypy` — typechecker clean on `src` + `tests` + `docs`
- [x] `uv run py.test --reruns 0 -vvv` — unit tests, doctests, and example tests all pass
- [x] `just build-docs` — Sphinx build succeeds; fresh `sphinx-build -a -E` shows the scope-comparison delta above
- [x] `{term}` `` `CJK` `` renders correctly in the built `docs/_build/html/index/index.html` and links to `glossary/index.html#term-CJK`
- [x] `docs/internals/api/index.md` appears in the built sidebar under Internals
- [x] `docs/topics/features.md` `cihai.conversion` cross-reference renders as a live link in the built HTML

## Out of scope

The remaining warnings on this branch are pre-existing on `master` too and each belongs to a separate cleanup:

- **Upstream `sphinx_autodoc_typehints` priority-ordering bug** — seven `:NN: (ERROR/3) Unexpected indentation` messages trace to `sphinx_autodoc_typehints/patches.py:75`, where `napoleon_numpy_docstring_return_type_processor` runs at `priority=499` (before `process_docstring` at `priority=500`) and inserts a `:` sentinel that typehints itself then chokes on during `get_insert_index`. Belongs upstream at `tox-dev/sphinx-autodoc-typehints`.
- **Archival `design-and-planning/*` pages** — fourteen `undefined label` warnings and two `myst.xref_missing` warnings on historical spec documents under `docs/design-and-planning/201{3,7,8}/`. Content bugs in frozen spec drafts; their own cleanup story.
- **Individual small items** — `Field list ends without a blank line` in `cihai.extend.ConfigMixin` docstring, `Duplicate reference definition: UV` in `CHANGES.rst`, `unknown role name: sqlalchemy:ref`, `Non-consecutive header level increase` in `docs/datasets/unihan.md`, and `Strikethrough is currently only supported in HTML output` in `CHANGES.rst`. Each is independent; intentionally untouched here to keep the PR focused on the six-bug set above.