### PR TITLE
Clean docs cross-references and Sphinx warnings

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -33,6 +33,24 @@ $ uvx --from 'cihai' --prerelease allow python -c "import cihai; print(cihai.__v
 _Notes on the upcoming release will go here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Documentation
+
+#### Documentation links point readers to the right APIs (#401)
+
+The documentation now links overview and topic prose directly to the
+classes, methods, modules, and dataset pages readers need next. The
+homepage, feature overview, extension guide, API reference stubs, and
+UNIHAN dataset page give readers a clearer path from the concept they
+are reading about to the exact {class}`cihai.core.Cihai`,
+{class}`cihai.extend.Dataset`, {class}`cihai.extend.DatasetPlugin`,
+and {class}`cihai.data.unihan.dataset.Unihan` APIs that implement it.
+
+Archival design notes remain available for project history, but their
+navigation links and external references no longer create broken
+documentation targets. The generated docs are quieter as a result, so
+future broken links and API-reference issues are easier to spot during
+review.
+
 ## cihai 0.38.0 (2026-06-28)
 
 cihai 0.38.0 raises the `unihan-etl` dependency floor to the 0.43.0

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -1,5 +1,9 @@
 # Config - `cihai.config`
 
+Use this module when you need to expand cihai configuration dictionaries before passing them to
+{class}`cihai.core.Cihai`. Most users only need {func}`cihai.config.expand_config` indirectly
+through the application object.
+
 ```{eval-rst}
 .. automodule:: cihai.config
    :members:

--- a/docs/api/constants.md
+++ b/docs/api/constants.md
@@ -1,5 +1,8 @@
 # Constants - `cihai.constants`
 
+These values define cihai's default directories, filenames, and baseline configuration. Start with
+{attr}`cihai.constants.DEFAULT_CONFIG` when you need to see what cihai uses without a config file.
+
 ```{eval-rst}
 .. automodule:: cihai.constants
    :members:

--- a/docs/api/conversion.md
+++ b/docs/api/conversion.md
@@ -2,6 +2,10 @@
 
 # Conversion - `cihai.conversion`
 
+Conversion helpers translate between Python strings and legacy CJK encodings. Reach for functions
+such as {func}`cihai.conversion.python_to_ucn` and {func}`cihai.conversion.ucn_to_unicode` when you
+need exact encoding conversion outside the high-level UNIHAN lookup flow.
+
 ```{eval-rst}
 .. automodule:: cihai.conversion
    :members:

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -1,5 +1,9 @@
 # Core - `cihai.core`
 
+{class}`cihai.core.Cihai` is the application object that owns configuration, database access, and
+datasets. Most code creates one instance, runs {meth}`cihai.core.Cihai.bootstrap` when needed, then
+queries the attached datasets.
+
 ```{eval-rst}
 .. automodule:: cihai.core
    :members:

--- a/docs/api/db.md
+++ b/docs/api/db.md
@@ -1,5 +1,8 @@
 # Database - `cihai.db`
 
+{class}`cihai.db.Database` wraps the SQLAlchemy engine, metadata, and session that datasets share.
+Use it directly only when you need raw database access instead of dataset helpers.
+
 ```{eval-rst}
 .. automodule:: cihai.db
    :members:

--- a/docs/api/exc.md
+++ b/docs/api/exc.md
@@ -1,7 +1,7 @@
 # Exceptions - `cihai.exc`
 
-When using cihai via Python, you can catch Cihai-specific exceptions via these. All Cihai-specific
-exceptions are catchable via {exc}`~cihai.exc.CihaiException` since its the base exception.
+When using cihai via Python, catch project-specific failures through this module. All Cihai-specific
+exceptions inherit from {exc}`~cihai.exc.CihaiException`.
 
 ```{eval-rst}
 .. automodule:: cihai.exc

--- a/docs/api/extend.md
+++ b/docs/api/extend.md
@@ -1,5 +1,9 @@
 # Extending - `cihai.extend`
 
+Extension classes let advanced users add datasets or dataset-specific behavior to
+{class}`cihai.core.Cihai`. Start with {class}`cihai.extend.Dataset`; use
+{class}`cihai.extend.DatasetPlugin` when the behavior belongs under an existing dataset.
+
 ```{eval-rst}
 .. automodule:: cihai.extend
    :members:

--- a/docs/api/log.md
+++ b/docs/api/log.md
@@ -1,5 +1,9 @@
 # Logging - `cihai.log`
 
+Logging helpers format cihai's command-line output. Library users normally configure logging in their
+application and leave {class}`cihai.log.LogFormatter` and {class}`cihai.log.DebugLogFormatter` to the
+CLI layer.
+
 ```{eval-rst}
 .. automodule:: cihai.log
    :members:

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -1,5 +1,8 @@
 # Typings - `cihai.types`
 
+These typed dictionaries describe cihai's public configuration shape. They are useful when annotating
+code that builds or validates a {class}`cihai.types.ConfigDict`.
+
 ```{eval-rst}
 .. automodule:: cihai.types
    :members:

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -1,5 +1,9 @@
 # Utilities - `cihai.utils`
 
+Utility helpers cover small behaviors shared across cihai internals. The most common advanced entry
+point is {func}`cihai.utils.import_string`, which resolves configured import paths into Python
+objects.
+
 ```{eval-rst}
 .. automodule:: cihai.utils
    :members:

--- a/docs/datasets/unihan.md
+++ b/docs/datasets/unihan.md
@@ -1,6 +1,10 @@
 # UNIHAN - `cihai.data.unihan`
 
-### Bootstrapping
+The {term}`UNIHAN` dataset gives a {class}`cihai.core.Cihai` application its default character
+lookup data: definitions, readings, variants, and related fields loaded through
+{ref}`unihan-etl:index`.
+
+## Bootstrapping
 
 ```{eval-rst}
 .. automodule:: cihai.data.unihan.bootstrap
@@ -21,7 +25,7 @@
    :show-inheritance:
 ```
 
-### Variants plugin
+## Variants plugin
 
 ```{eval-rst}
 .. autoclass:: cihai.data.unihan.dataset.UnihanVariants

--- a/docs/design-and-planning/2013/information_liberation.md
+++ b/docs/design-and-planning/2013/information_liberation.md
@@ -97,5 +97,5 @@ permissive license will open your work to the world.
   v1.0]
 - [MIT License]
 
-[mit license]: _http://opensource.org/licenses/MIT
+[mit license]: http://opensource.org/licenses/MIT
 [open data commons attribution license (odc-by) v1.0]: http://opendatacommons.org/licenses/by/1.0

--- a/docs/design-and-planning/2013/spec.md
+++ b/docs/design-and-planning/2013/spec.md
@@ -63,7 +63,7 @@ Unihan Inc. is the center of the universe for all glyphs. For those who study Eg
 hieroglyphics, which are still mysterious, they are covered in Unicode block
 [U+13000..U+1342F].
 
-[u+13000..u+1342f]: Fhttp://en.wikipedia.org/wiki/Egyptian_Hieroglyphs_(Unicode_block)
+[u+13000..u+1342f]: http://en.wikipedia.org/wiki/Egyptian_Hieroglyphs_(Unicode_block)
 [unihan's history]: http://www.unicode.org/reports/tr38/#History
 [cjkxref.txt]: http://www.unicode.org/Public/1.1-Update/CJKXREF.TXT
 [unihan-1.txt]: http://www.unicode.org/Public/2.0-Update/Unihan-1.txt
@@ -439,7 +439,7 @@ Cihai will allows extensibility to new dictionaries, vocabularies and data.
 
 Middleware allows an arbitrary plugin to make data available.
 
-By default, `Cihai()` creates an instance of Cihai with access to {meth}`Cihai.get`.
+By default, `Cihai()` creates an instance of Cihai with access to `Cihai.get`.
 
 However, since no middleware are included with Cihai, no results are returned.
 

--- a/docs/design-and-planning/2017/spec.md
+++ b/docs/design-and-planning/2017/spec.md
@@ -8,24 +8,24 @@ orphan: true
 
 Created 2017-04-29
 
-1. {ref}`zero_config` - cihai should be able to work without configuration with a default data
+1. {ref}`zero-config` - cihai should be able to work without configuration with a default data
    backend.
-2. {ref}`incremental_config` cihai should be incrementally configurable, such as by specifying where
+2. {ref}`incremental-config` cihai should be incrementally configurable, such as by specifying where
    data should be outputted.
-3. {ref}`relational_backend` cihai will use [SQLAlchemy] as a database backend to story
+3. {ref}`relational-backend` cihai will use [SQLAlchemy] as a database backend to story
    information for retrieval.
-4. {ref}`automatic_extensions` cihai will make data accessible to third party libraries if they
+4. {ref}`automatic-extensions` cihai will make data accessible to third party libraries if they
    exist in the script's site-packages.
 
    e.g. If [pandas] is found, it will be able to return a {class}`pandas.DataFrame` for a
    queried set of information.
 
-5. {ref}`unihan_core` cihai will use [UNIHAN] as a core and source of truth for information,
+5. {ref}`unihan-core` cihai will use [UNIHAN] as a core and source of truth for information,
    as it contains all the glyphs and is reliable, free and well-maintained, and provides are good
    source of starter information.
-6. {ref}`data_normalization` cihai will adopt a standard data format to store additional CJK data
+6. {ref}`data-normalization` cihai will adopt a standard data format to store additional CJK data
    sets within.
-7. {ref}`data_liberation` cihai libraries will be available under permissive licenses.
+7. {ref}`data-liberation` cihai libraries will be available under permissive licenses.
 
 (zero-config)=
 
@@ -43,7 +43,7 @@ out data to. This includes:
   name used within, e.g. _cihai.yaml_
 
 These default directories will be where cihai will, by default, store information and search for
-configuration used in {ref}`incremental_config`.
+configuration used in {ref}`incremental-config`.
 
 (incremental-config)=
 
@@ -61,7 +61,7 @@ to store the SQLite file, is customizable.
 cihai will be powered by a relational database backend.
 
 Most python distributions include support for [SQLite], which in conjunction with
-{ref}`zero configuration <zero_config>`, makes for data store that will work across a wide array of
+{ref}`zero configuration <zero-config>`, makes for data store that will work across a wide array of
 systems.
 
 The data that cihai organizes will be primarily indexable by the glyph, and joined upon the glyph to

--- a/docs/design-and-planning/index.md
+++ b/docs/design-and-planning/index.md
@@ -4,20 +4,20 @@
 
 ## 2018
 
-- {ref}`design-and-planning/2018/plugin-system`
+- {doc}`Extensions <2018/plugin-system>`
 
 ## 2017
 
-- {ref}`design-and-planning/2017/spec`
+- {doc}`Internals Planning <2017/spec>`
 
 ## Late 2013
 
 These were part of the initial brain storming the project and preserved for historic purposes only.
 
-- {ref}`design-and-planning/2013/extending`
-- {ref}`design-and-planning/2013/internals`
-- {ref}`design-and-planning/2013/information_liberation`
-- {ref}`design-and-planning/2013/spec`
+- {doc}`Extending <2013/extending>`
+- {doc}`Internal Design decisions <2013/internals>`
+- {doc}`Information Liberation <2013/information_liberation>`
+- {doc}`Planning <2013/spec>`
 
 ## Late 2012
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,6 +64,12 @@ $ uv add cihai
 
 ## At a glance
 
+Most projects start with {class}`cihai.core.Cihai`: create the application object, bootstrap the
+{attr}`~cihai.core.Cihai.unihan` dataset once with
+{meth}`~cihai.data.unihan.dataset.Unihan.bootstrap`, then query it with
+{meth}`~cihai.data.unihan.dataset.Unihan.lookup_char` or
+{meth}`~cihai.data.unihan.dataset.Unihan.reverse_char`.
+
 ```python
 from cihai.core import Cihai
 

--- a/docs/internals/api/config_reader.md
+++ b/docs/internals/api/config_reader.md
@@ -1,5 +1,9 @@
 # Config reader - `cihai._internal.config_reader`
 
+{class}`cihai._internal.config_reader.ConfigReader` loads and dumps raw YAML or JSON configuration
+data before the public configuration layer expands it. This is an internal API with no compatibility
+guarantee.
+
 ```{eval-rst}
 .. automodule:: cihai._internal.config_reader
    :members:

--- a/docs/internals/api/index.md
+++ b/docs/internals/api/index.md
@@ -2,6 +2,9 @@
 
 # Internal API
 
+These references document cihai internals for maintainers. Use the public API pages unless you are
+debugging configuration loading or contributing changes to cihai itself.
+
 ```{module} cihai
 
 ```

--- a/docs/internals/api/types.md
+++ b/docs/internals/api/types.md
@@ -1,5 +1,8 @@
 # Typings - `cihai._internal.types`
 
+Internal type aliases support configuration loading and expansion. Prefer the public types in
+{mod}`cihai.types` unless you are working on cihai internals.
+
 ```{eval-rst}
 .. automodule:: cihai._internal.types
    :members:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -53,8 +53,8 @@ You can override cihai's default storage and file directories via a config file.
 
 The default configuration is at {attr}`cihai.constants.DEFAULT_CONFIG`.
 
-Database configuration accepts any SQLAlchemy {sqlalchemy:ref}`database_urls`. If you're using a DB
-other than SQLite, such as Postgres, be sure to install the requisite driver, such as
+Database configuration accepts any SQLAlchemy {external+sqlalchemy:ref}`database_urls`. If you're
+using a DB other than SQLite, such as Postgres, be sure to install the requisite driver, such as
 [psycopg][psycopg].
 
 [xdg directories]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-0.6.html
@@ -63,7 +63,7 @@ other than SQLite, such as Postgres, be sure to install the requisite driver, su
 
 cihai is designed to allow you to incrementally override settings to your liking.
 
-Internally, the config is parsed through {func}`cihai.conf.expand_config`. This will replace
+Internally, the config is parsed through {func}`cihai.config.expand_config`. This will replace
 environment variables, XDG variables and tildes. You can also enter absolute paths.
 
 Environmental variables require a dollar sign added to them, e.g. `${ENVVAR}`. XDG variables such as

--- a/docs/topics/extending.md
+++ b/docs/topics/extending.md
@@ -2,8 +2,8 @@
 
 # Extending cihai
 
-Use cihai's abstraction and your dataset's users can receive easy configuration, SQL access, and be
-available in a growing list of CJKV information.
+Use cihai's abstraction and your dataset's users can receive easy configuration,
+{term}`SQLAlchemy` access, and be available in a growing list of CJKV information.
 
 ## Creating new dataset
 
@@ -19,8 +19,8 @@ _examples/dataset.py_:
 
 ```
 
-In addition, view our reference implementation of UNIHAN, which is incorporated as a dataset. See
-{class}`cihai.data.unihan.dataset.Unihan`
+In addition, view our reference implementation of the {doc}`UNIHAN dataset <../datasets/unihan>`.
+See {class}`cihai.data.unihan.dataset.Unihan`.
 
 [issue tracker]: https://github.com/cihai/cihai/issues
 

--- a/docs/topics/features.md
+++ b/docs/topics/features.md
@@ -2,28 +2,28 @@
 
 # Features
 
-- Handling CJK Variants
+- Handling {term}`CJK` variants
 
-  cihai builds upon [UNIHAN]: "thousands of years worth of
+  cihai builds upon the {doc}`UNIHAN dataset <../datasets/unihan>`: "thousands of years worth of
   writing have produced thousands of pairs which can be used more-or-less interchangeably." For more
   information, see "Unification Rules" on page 679 of _The Unicode Standard_
   ([.pdf](http://www.unicode.org/versions/Unicode9.0.0/ch18.pdf)).
 
 - Extensibie
 
-  cihai will be able to pull remote CJK datasets.
+  cihai will be able to pull remote {term}`CJK` datasets.
 
   In addition, the handling of variants will create new ways to discover and interpret CJK
   characters while using these datasets.
 
 - Python API and CLI application
 
-  Cihai can be used as a Python {ref}`API` as well as a command line application via `$ cihai`.
+  {class}`cihai.core.Cihai` can be used as a Python {ref}`API <api>` as well as a command line
+  application via `$ cihai`.
 
 - Asian encoding swiss army knife
 
-  Functions under the hood such as {ref}`cihai.conversion <cihai.conversion>` are tested across
+  Functions under the hood such as {mod}`cihai.conversion` are tested across
   python implementations to handle a growing assortment of Asian encodings.
 
-[unihan]: http://unicode.org/charts/unihan.html
 [variants]: http://www.unicode.org/reports/tr38/tr38-21.html#N10211

--- a/src/cihai/extend.py
+++ b/src/cihai/extend.py
@@ -38,28 +38,19 @@ class ConfigMixin:
     Cihai will automatically manage the user's config, as well as your datasets,
     neatly in XDG.
 
-    Raises
-    ------
-    Functions inside, and what you write relating to dataset config should return
-
-    CihaiDatasetConfigException (CihaiDatasetException)
-
-    config.cihai = links directly back to Cihai's configuration dictionary
-    (todo note: make this non-mutable property)
-
-    config : dict
-        your local user's config
-
-    check() : function, optional
-        this is ran on start. it can raise DatasetConfigException
-
-    default_config : your dataset's default configuration
-
-    get_default_config : override function in case you'd like custom configs (for
-        instance if you want a platform to use a different db driver, or do version
-        checks, etc.)
-
-        internal functions use get_default_config()
+    Configuration attributes
+    ------------------------
+    ``config.cihai``
+        Links directly back to Cihai's configuration dictionary.
+    ``config``
+        Your local user's config.
+    ``check()``
+        Optional function run on start. It can raise dataset config exceptions.
+    ``default_config``
+        Your dataset's default configuration.
+    ``get_default_config``
+        Override function for custom configs, such as platform-specific database
+        drivers or version checks. Internal functions use ``get_default_config()``.
     """
 
 


### PR DESCRIPTION
## Summary

This PR cleans up documentation cross-references so API objects, methods, and topic pages link correctly from prose. It also preserves the historical design-and-planning pages while fixing broken references and URL typos that produced Sphinx warnings.

The API and dataset stub pages now open with short concept-first prose before autodoc, and the `ConfigMixin` docstring is reshaped so autodoc renders it cleanly.

## Verification

- `rm -rf docs/_build; uv run ruff check . --fix --show-fixes; uv run ruff format .; uv run mypy .; uv run py.test --reruns 0 -vvv; just build-docs;`
- Post-commit: `uv run py.test --reruns 0 -vvv` -> 53 passed