### PR TITLE
docs(types): Document config TypedDict keys

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -60,6 +60,13 @@ Workflow actions moved to their current major releases: `actions/checkout` v7,
 and `dorny/paths-filter` v4. Workflow behavior is unchanged, though setup-uv no
 longer prunes the uv cache, so the first run after this repopulates it.
 
+#### Configuration fields describe themselves in the API reference (#403)
+
+The `TypedDict` keys that describe cihai's configuration and directory
+layout now say what each one holds. They previously reached the rendered API
+reference as "Alias for field number 0" or as a bare name carrying only its
+type.
+
 ## cihai 0.38.0 (2026-06-28)
 
 cihai 0.38.0 raises the `unihan-etl` dependency floor to the 0.43.0

--- a/src/cihai/types.py
+++ b/src/cihai/types.py
@@ -35,7 +35,23 @@ class RawPluginConfigDict(TypedDict):
 
 
 class RawDirsConfigDict(TypedDict):
-    """Raw directory config dictionary."""
+    """Raw directory config dictionary.
+
+    Values may be :py:class:`str` templates holding XDG placeholders such as
+    ``{user_cache_dir}``, environment variables, or a tilde;
+    :func:`cihai.config.expand_config` resolves them to
+    :py:class:`pathlib.Path`.
+
+    Attributes
+    ----------
+    cache : str | pathlib.Path
+        Cache directory, defaulting to the XDG user cache directory.
+    log : str | pathlib.Path
+        Log directory, defaulting to the XDG user log directory.
+    data : str | pathlib.Path
+        Persistent data directory, home to the SQLite database in the default
+        config, defaulting to the XDG user data directory.
+    """
 
     cache: str | pathlib.Path
     log: str | pathlib.Path
@@ -43,7 +59,21 @@ class RawDirsConfigDict(TypedDict):
 
 
 class DirsConfigDict(TypedDict):
-    """Directory config dictionary."""
+    """Directory config dictionary.
+
+    Resolved counterpart of :class:`RawDirsConfigDict`: templates, environment
+    variables, and tildes are already expanded.
+
+    Attributes
+    ----------
+    cache : pathlib.Path
+        Cache directory, defaulting to the XDG user cache directory.
+    log : pathlib.Path
+        Log directory, defaulting to the XDG user log directory.
+    data : pathlib.Path
+        Persistent data directory, home to the SQLite database in the default
+        config, defaulting to the XDG user data directory.
+    """
 
     cache: pathlib.Path
     log: pathlib.Path
@@ -51,13 +81,43 @@ class DirsConfigDict(TypedDict):
 
 
 class RawDatabaseConfigDict(TypedDict):
-    """Raw database config dictionary."""
+    """Raw database config dictionary.
+
+    Attributes
+    ----------
+    url : str
+        SQLAlchemy database URL, handed to
+        :func:`sqlalchemy.create_engine` by :class:`cihai.db.Database`. Before
+        :func:`cihai.config.expand_config` runs it may carry XDG placeholders,
+        as the default ``sqlite:///{user_data_dir}/cihai.db`` does.
+    """
 
     url: str
 
 
 class RawConfigDict(TypedDict):
-    """Raw, unresolved configuration dictionary."""
+    """Raw, unresolved configuration dictionary.
+
+    Shape a caller passes to :class:`cihai.core.Cihai`, before it is merged
+    over :data:`cihai.constants.DEFAULT_CONFIG` and its templates expanded.
+
+    Attributes
+    ----------
+    plugins : NotRequired[dict[str, RawPluginConfigDict]]
+        Dataset plugins, keyed by the namespace of the dataset they extend.
+        Omitted when no dataset carries plugins.
+    datasets : dict[str, str | Dataset]
+        Datasets to bootstrap, keyed by the attribute namespace they are bound
+        to on the :class:`cihai.core.Cihai` object. A value is either a dotted
+        import path resolved through :func:`cihai.utils.import_string` or a
+        :class:`cihai.extend.Dataset` subclass.
+    database : RawDatabaseConfigDict
+        Database connection settings.
+    dirs : RawDirsConfigDict
+        Cache, log, and data directories.
+    debug : bool
+        Debug flag, ``False`` in the default config.
+    """
 
     plugins: NotRequired[dict[str, RawPluginConfigDict]]
     datasets: dict[str, str | Dataset]
@@ -67,7 +127,29 @@ class RawConfigDict(TypedDict):
 
 
 class ConfigDict(TypedDict):
-    """Cihai Configuration dictionary."""
+    """Cihai Configuration dictionary.
+
+    Shape of :attr:`cihai.core.Cihai.config`: user input merged over
+    :data:`cihai.constants.DEFAULT_CONFIG` with templates expanded, so every
+    key is present.
+
+    Attributes
+    ----------
+    plugins : dict[str, RawPluginConfigDict]
+        Dataset plugins, keyed by the namespace of the dataset they extend. An
+        empty mapping when no dataset carries plugins.
+    datasets : dict[str, str | Dataset]
+        Datasets to bootstrap, keyed by the attribute namespace they are bound
+        to on the :class:`cihai.core.Cihai` object. A value is either a dotted
+        import path resolved through :func:`cihai.utils.import_string` or a
+        :class:`cihai.extend.Dataset` subclass.
+    database : RawDatabaseConfigDict
+        Database connection settings.
+    dirs : RawDirsConfigDict
+        Cache, log, and data directories.
+    debug : bool
+        Debug flag, ``False`` in the default config.
+    """
 
     plugins: dict[str, RawPluginConfigDict]
     datasets: dict[str, str | Dataset]


### PR DESCRIPTION
The config `TypedDict`s in `cihai.types` carried a one-line docstring and nothing else, so autodoc rendered each key bare in the API reference — a reader landing on `ConfigDict` saw the key name and its type annotation with no indication of what the value holds, where it comes from, or when it may be absent. Each of these classes now carries a NumPy-style `Attributes` section naming every key, what it holds, its default, and where a raw string template is resolved.

Gates run and passing: `just ruff-format`, `just ruff`, `uv run mypy .`, `just test`, `just build-docs`.

The docs build succeeds but now emits duplicate-object warnings for every documented key (`duplicate object description of cihai.types.ConfigDict.debug, other instance in api/types`). The NumPy preprocessor emits an `.. attribute::` directive for each entry in the `Attributes` section while autodoc separately renders the same field, so each key is described twice and the second, undescribed copy still shows in the page. That is a gp-sphinx issue rather than one for this branch, and a fix is landing there; `docs/conf.py` is deliberately left alone here.

Closes #402
